### PR TITLE
Since SNPs between pharmvar and genotype data need to be matched on b…

### DIFF
--- a/src/main/java/org/molgenis/asterix/io/SnpToHaploTableReader.java
+++ b/src/main/java/org/molgenis/asterix/io/SnpToHaploTableReader.java
@@ -74,24 +74,27 @@ public class SnpToHaploTableReader {
         if (id.equals("-")) snp.setId(snp.getChr() + ":" + snp.getPos() + ":" + snp.getReferenceAllele());
         else snp.setId(id);
 
-
         if (snp.getPos() > gene.getEndPos()) gene.setEndPos(snp.getPos());
         if (snp.getPos() < gene.getStartPos()) gene.setStartPos(snp.getPos());
 
-        if (splitLine[7].equals("-")) snp.setVariantAllele(splitLine[6]); // TODO what about indels
-        else snp.setVariantAllele(splitLine[7]);
+        //if (splitLine[7].equals("-")) snp.setVariantAllele(splitLine[6]); // TODO what about indels
+        //else snp.setVariantAllele(splitLine[7]);
+        snp.setVariantAllele(splitLine[7]);
 
-        if (!gene.getWildType().hasSnp(snp)) {
-            Snp wildTypeSnp = snp.copySnp(snp);
-            wildTypeSnp.setVariantAllele(wildTypeSnp.getReferenceAllele());
-            gene.getWildType().addSnp(wildTypeSnp);
+        if (!gene.hasVariant(snp)) {
+            gene.addVariant(snp);
         }
+
+        if (!gene.getWildType().hasVariantAllele(snp.getId())) {
+            gene.getWildType().addVariantAlleles(snp.getId(), snp.getReferenceAllele());
+        }
+
         if (gene.getPgxHaplotypes().containsKey(haplotypeName)) {
             PgxHaplotype pgxHaplotype = gene.getPgxHaplotypes().get(haplotypeName);
-            pgxHaplotype.addSnp(snp);
+            pgxHaplotype.addVariantAlleles(snp.getId(), snp.getVariantAllele());
         } else {
-            PgxHaplotype pgxHaplotype = new PgxHaplotype(haplotypeName);
-            pgxHaplotype.addSnp(snp);
+            PgxHaplotype pgxHaplotype = new PgxHaplotype(gene, haplotypeName);
+            pgxHaplotype.addVariantAlleles(snp.getId(), snp.getVariantAllele());
             gene.getPgxHaplotypes().put(haplotypeName, pgxHaplotype);
         }
     }

--- a/src/main/java/org/molgenis/asterix/model/PgxHaplotype.java
+++ b/src/main/java/org/molgenis/asterix/model/PgxHaplotype.java
@@ -5,33 +5,39 @@ import java.util.Map;
 
 public class PgxHaplotype {
 
-    private Map<String, Snp> snps = new HashMap<>();
+    private PgxGene gene;
+    private Map<String, String> variantAlleles = new HashMap<>();
     private String name;
     private String function;
 
-    public PgxHaplotype(String name) {
+    public PgxHaplotype(PgxGene gene, String name) {
         this.name = name;
+        this.gene = gene;
     }
 
-    public void addSnp(Snp snp) {
-        snps.put(snp.getId(), snp);
-    }
+//    public void addSnp(Snp snp) {
+//        snps.put(snp.getId(), snps);
+//    }
 
-    public boolean hasSnp(Snp snp) {
-        return snps.containsKey(snp.getId());
-    }
+//    public boolean hasSnp(Snp snp) {
+//        return snps.containsKey(snp.getId());
+//    }
 
-    public void removeSnp(Snp snp) {
-        snps.remove(snp.getId());
-    }
+//    public void removeSnp(Snp snp) {
+//        snps.remove(snp.getId());
+//    }
 
     public Map<String, Snp> getSnps() {
+        Map<String, Snp> snps = new HashMap<>();
+        for (String id: this.variantAlleles.keySet()) {
+            snps.put(id, this.gene.getVariants().get(id));
+        }
         return snps;
     }
 
-    public void setSnps(Map<String, Snp> snps) {
-        this.snps = snps;
-    }
+//    public void setSnps(Map<String, Snp> snps) {
+//        this.snps = snps;
+//    }
 
     public String getName() {
         return name;
@@ -52,9 +58,29 @@ public class PgxHaplotype {
     @Override
     public String toString() {
         return "PgxHaplotype{" +
-                "snps=" + snps +
+                "snps=" + this.getSnps() +
                 ", name='" + name + '\'' +
                 ", function='" + function + '\'' +
                 '}';
+    }
+
+    public Map<String, String> getVariantAlleles() {
+        return variantAlleles;
+    }
+
+    public void setVariantAlleles(Map<String, String> variantAlleles) {
+        this.variantAlleles = variantAlleles;
+    }
+
+    public void addVariantAlleles(String id, String variantAllele) {
+        this.variantAlleles.put(id, variantAllele);
+    }
+
+    public void removeVariantAllele(Snp pgxSnp) {
+        variantAlleles.remove(pgxSnp.getId());
+    }
+
+    public boolean hasVariantAllele(String id) {
+        return variantAlleles.containsKey(id);
     }
 }

--- a/src/main/java/org/molgenis/asterix/model/Snp.java
+++ b/src/main/java/org/molgenis/asterix/model/Snp.java
@@ -1,5 +1,9 @@
 package org.molgenis.asterix.model;
 
+import org.molgenis.genotype.annotation.Annotation;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class Snp {
@@ -16,6 +20,7 @@ public class Snp {
     private Double maf;
     private boolean isAvailable;
     private double hwePvalue;
+    private Map<String, String> annotationValues;
 
     public int getChr() {
         return chr;
@@ -108,7 +113,7 @@ public class Snp {
     public Snp copySnp(Snp snpToCopy) {
         Snp snp = new Snp();
         snp.setVariantAllele(snpToCopy.getVariantAllele());
-        snp.setReferenceAllele(snpToCopy.getVariantAllele());
+        snp.setReferenceAllele(snpToCopy.getReferenceAllele());
         snp.setPos(snpToCopy.getPos());
         snp.setChr(snpToCopy.getChr());
         snp.setId(snpToCopy.getId());
@@ -117,6 +122,7 @@ public class Snp {
         snp.setMaf(snpToCopy.getMaf());
         snp.setrSquared(snpToCopy.getrSquared());
         snp.setAvailable(snpToCopy.isAvailable());
+        snp.setAnnotations(snpToCopy.getAnnotations());
 
         return snp;
     }
@@ -162,5 +168,20 @@ public class Snp {
 
     public void setHwe(double hwePvalue) {
         this.hwePvalue = hwePvalue;
+    }
+
+    public void setAnnotations(Map<String, String> annotationValues) {
+        this.annotationValues = annotationValues;
+    }
+
+    public Map<String, String> getAnnotations() {
+        if (annotationValues == null) {
+            return new HashMap<>();
+        }
+        return annotationValues;
+    }
+
+    public double getHwe() {
+        return hwePvalue;
     }
 }


### PR DESCRIPTION
…oth genomic position and alleles, reference and alt alleles are now stored in SNP objects in each gene. In haplotypes the variant allele is stored. This is ref for wild type for instance.

This resolves issues with indels.

Also includes other info fields depending on what is available.